### PR TITLE
Honor the skip_backport_check input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function init() {
     required: false,
   });
 
-  const skipBackportCheck = core.getInput('skip_backport_check_label', {
+  const skipBackportCheck = core.getInput('skip_backport_check', {
     required: false,
   });
 


### PR DESCRIPTION
The `skipBackportCheck` const was previously being set to the value of the `skip_backport_check_label` input, not `skip_backport_check`.