### PR TITLE
Update documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ For more fine grained customization, and for the ability to run the [Backport To
 ```
 
 
- See the [Backport Tool documentation](https://github.com/sqren/backport/blob/main/docs/configuration.md) for all configuration options.
+ See the [Backport Tool documentation](https://github.com/sqren/backport#documentation) for all configuration options.
 

--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ For more fine grained customization, and for the ability to run the [Backport To
 ```
 
 
- See the [Backport Tool documentation](https://github.com/sqren/backport#documentation) for all configuration options.
+ See the [Backport Tool documentation](https://github.com/sqren/backport/blob/main/docs/config-file-options.md) for all configuration options.
 


### PR DESCRIPTION
I'm not sure where you'd like this to point, but the current link is a 404.