### PR TITLE
fix(release): mirror action version to backport via `npm version`

### DIFF
--- a/.cursor/skills/release-backport-action/SKILL.md
+++ b/.cursor/skills/release-backport-action/SKILL.md
@@ -23,16 +23,32 @@ release rather than getting its own version.
 On each push to `main` it:
 
 1. Reads the bundled `backport` version. If `vX.Y.Z` is already tagged, it stops.
-2. Sets `package.json` to that version and rebuilds the committed bundle (`dist/`).
-3. Commits, tags `vX.Y.Z`, force-moves the major tag `vN`, and creates the GitHub
-   Release (`--generate-notes --latest`). Only tags are pushed (never `main`), so
-   the built-in `GITHUB_TOKEN` is sufficient.
+2. Checks that `package.json`'s `version` already equals it (the version is synced
+   in the PR, **not** here — the workflow only pushes tags, so a release-time bump
+   could never reach protected `main`). Then it rebuilds the bundle (`dist/`).
+3. Commits the rebuilt `dist/`, tags `vX.Y.Z`, force-moves the major tag `vN`, and
+   creates the GitHub Release (`--generate-notes --latest`). Only tags are pushed
+   (never `main`), so the built-in `GITHUB_TOKEN` is sufficient.
 
 ## Upgrading backport
 
-[Dependabot](../../../.github/dependabot.yml) opens a PR whenever a new
-`backport` is published (including minor/patch). Merge it — the workflow releases
-the matching action version automatically.
+[Dependabot](../../../.github/dependabot.yml) opens a PR whenever a new `backport`
+is published (including minor/patch). Dependabot bumps the dependency but not the
+action's own `version`, so mirror it before merge (CI blocks the merge until it
+matches):
+
+```bash
+gh pr checkout <pr-number>
+npm ci
+npm run sync-version     # npm version <backport> --no-git-tag-version
+git commit -am "chore: mirror backport version"
+git push
+```
+
+Then merge — the release workflow tags the matching action version automatically.
+The mirror lives in the PR, not the release workflow, because that is the only
+tokenless way to keep `main`'s `package.json` truthful: the workflow never pushes
+to protected `main`.
 
 ## Manual action-only release
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     # can mirror its version — a wildcard ignore is exactly what previously kept the
     # action pinned behind backport. If unrelated-dependency noise becomes a problem,
     # add a targeted ignore for those specific dependencies, never `dependency-name: "*"`.
+    #
+    # When a backport-bump PR lands here, also mirror the action's own version:
+    # `npm run sync-version && git commit -am "chore: mirror backport version"`.
+    # CI blocks the merge until package.json matches backport — see
+    # .cursor/skills/release-backport-action/SKILL.md.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Mirror the bundled backport version (bumped on main by Dependabot).
+          # The action's version mirrors the bundled backport version. main already
+          # carries it in package.json (synced in the PR) — a release only pushes
+          # tags, never protected main, so it can't bump the version here.
           VERSION=$(node -p "require('./node_modules/backport/package.json').version")
           MAJOR=${VERSION%%.*}
 
@@ -51,12 +53,17 @@ jobs:
             exit 0
           fi
 
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          # Fail loudly if main ever drifted instead of shipping a mismatched tag.
+          test "$(npm pkg get version | tr -d '"')" = "$VERSION" ||
+            { echo "::error::package.json version != backport ($VERSION). Run 'npm run sync-version' in the PR."; exit 1; }
+
           npm run build
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore: release v$VERSION" --no-verify
+          # The version field is already correct; this commit only captures the
+          # freshly built dist/ for the tag (--allow-empty: dist may already match).
+          git commit -am "chore: release v$VERSION" --no-verify --allow-empty
           git tag "v$VERSION"
           git tag -f "v$MAJOR"
 

--- a/.github/workflows/run-lint-and-tests.yml
+++ b/.github/workflows/run-lint-and-tests.yml
@@ -22,6 +22,15 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+      # The action's version must equal the bundled backport version. A PR that
+      # bumps backport must run `npm run sync-version` too, or main drifts behind
+      # the release. Keep this a required status check so it blocks merge.
+      - name: Verify version mirrors backport
+        run: |
+          have=$(npm pkg get version | tr -d '"')
+          want=$(node -p "require('./node_modules/backport/package.json').version")
+          test "$have" = "$want" ||
+            { echo "::error::package.json version ($have) must equal backport ($want). Run: npm run sync-version"; exit 1; }
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backport-github-action",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backport-github-action",
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport-github-action",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -8,7 +8,8 @@
     "prepare": "husky",
     "lint": "eslint '{src,scripts}/**/*.ts' && tsc --noEmit --project tsconfig.eslint.json",
     "test": "vitest run",
-    "test:e2e": "npx tsx scripts/smoke-test/smoke-test.ts"
+    "test:e2e": "npx tsx scripts/smoke-test/smoke-test.ts",
+    "sync-version": "npm version $(node -p \"require('./node_modules/backport/package.json').version\") --no-git-tag-version --allow-same-version"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## The bug

Merging [#182](https://github.com/sorenlouv/backport-github-action/pull/182) (backport `^12.0.1`) published [v12.0.1](https://github.com/sorenlouv/backport-github-action/releases/tag/v12.0.1), but `main`'s `package.json` stayed at `12.0.0`.

**Root cause:** `release.yml` bumped the version with `npm version`, then pushed **only tags, never `main`** (the deliberate tokenless design — `GITHUB_TOKEN` can't push to protected `main`). So the bump lived only inside the orphan tag commit, and `main` drifted behind every release.

## The fix — standard tooling, no custom script

The version can't be set at release time, so it's mirrored **in the PR** using the wheel that already exists (`npm version`):

- **`package.json`**: `12.0.0 → 12.0.1`; one new script `sync-version` = `npm version <backport> --no-git-tag-version --allow-same-version`.
- **`package-lock.json`**: its root version was stale at `12.0.0` too — `npm version` keeps both in sync (the old hand-rolled approach missed this).
- **`run-lint-and-tests.yml`**: a small step asserts `package.json` version `==` backport, so a backport bump can't merge without running `npm run sync-version`. **Keep this a required status check** so it blocks merge.
- **`release.yml`**: dropped `npm version`; it now just verifies the version already matches before tagging (fails loudly otherwise). The release commit only captures rebuilt `dist/` (`--allow-empty`).
- Docs (`SKILL.md`, `dependabot.yml`): the one-command sync.

The check is a plain `test "$(npm pkg get version)" = "$(node -p backport.version)"` — no bespoke logic to maintain.

## Bumping backport (e.g. Dependabot)

One extra command before merge, enforced by CI:

```bash
gh pr checkout <pr> && npm ci && npm run sync-version && git commit -am "chore: mirror backport version" && git push
```

## After merge

`release.yml` no-ops (`v12.0.1` is already tagged) — no duplicate release — and `main` correctly shows `12.0.1`. Every future backport bump keeps it in sync.

## Verification

`lint`, `test`, `build` all pass. The version gate was tested positive and negative; `sync-version` correctly fixes both `package.json` and the lockfile; all three YAML files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)